### PR TITLE
Fix #14 Download button for attachments

### DIFF
--- a/src/components/shapes/Distribution.js
+++ b/src/components/shapes/Distribution.js
@@ -67,7 +67,7 @@ const Preview = (mediaType, downloadURL) => {
  * @param {string} uri
  * @param {string} fileName
  */
-function fetchAttachment(uri, fileNamem, token) {
+function fetchAttachment(uri, fileName, token) {
   return () => {
     downloadAttachment(uri, fileName, token);
   };


### PR DESCRIPTION
Should be able to download file now :)

For https://bbp-nexus.epfl.ch/staging/explorer/sandbox/test5e31122f734447d38c57/person/v0.1.1/fd04e128-3c9d-41b9-b2c1-5bcea2bfe6b0: 

- Media Type is empty because originalFileName is `file`, which doesn't have an extension and Media Type is based on the file extension.
- File is downloaded with txt extension because of https://github.com/eligrey/FileSaver.js ...
- txt extension can be renamed to .png to view the file properly (image below)

![image](https://user-images.githubusercontent.com/3300313/39851852-6837f9c8-53e7-11e8-9f6d-c22615a51573.png)
