### PR TITLE
add samesite + host prefix + secure

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -7,12 +7,15 @@ import AuthContext, { AuthContextState } from '../shared/context/AuthContext';
 const rawBase: string = (window as any)['__BASE__'] || '/';
 // remove trailing slash
 const base: string = rawBase.replace(/\/$/, '');
+// Are we running with SSL
+const isSecure = location.protocol === 'https';
+const cookieName = isSecure ? '__Host-nexusAuth' : '_Host-nexusAuth';
 
 // get auth data from cookies
 // TODO: this is a POC, this code needs to be improved and tested
 function getAuthData(): AuthContextState {
   const all: string[] = decodeURIComponent(document.cookie).split(';');
-  const rawAuthCookie: string = all.filter(cookie => cookie.includes('nexusAuth='))[0];
+  const rawAuthCookie: string = all.filter(cookie => cookie.includes(`${cookieName}=`))[0];
   if (!rawAuthCookie) {
     return {
       authenticated: false,
@@ -20,7 +23,7 @@ function getAuthData(): AuthContextState {
   }
   let authCookie: {accessToken: string};
   try {
-    authCookie = JSON.parse(rawAuthCookie.replace('nexusAuth=', ''));
+    authCookie = JSON.parse(rawAuthCookie.replace(`${cookieName}=`, ''));
   } catch (e) {
     return {
       authenticated: false,


### PR DESCRIPTION
I've added:

- `SameSite` which disables cross-origin requests and set it to `strict` so we only send the cookie when site is directly navigated to
- `Secure` so cookies are only sent over HTTPS
- `__Host-` prefix which means we only send cookies over HTTPS and subdomains aren't allowed
