### PR TITLE
Update OC strategy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
                 expression { isMaster && !isRelease && !isPR }
             }
             steps {
-                sh "oc start-build ${imageBuildName} --from-dir=. --follow"
+                sh "oc start-build ${imageBuildName} --follow"
             }
         }
 


### PR DESCRIPTION
OC is now cloning the repo directly from git, rather than Jenkins sending is as binary