### PR TITLE
Fix Redux DevTools error

### DIFF
--- a/src/shared/store/index.ts
+++ b/src/shared/store/index.ts
@@ -17,11 +17,11 @@ export type Services = {
 
 export type ThunkAction = ThunkAction<Promise<any>, object, Services, any>;
 
-let composeEnhancers = compose;
+let composeEnhancers: Function;
 try {
   composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
 } catch (e) {
-  // fail silently
+  composeEnhancers = compose;
 }
 
 export default function configureStore(


### PR DESCRIPTION
For some reason the previous approach was setting composeEnhancers() to undefined after transpiling and optimization if Redux DevTools was not available. This approach makes sure we always have a valid composeEnhancers() function.