### PR TITLE
Bugfix/label input and refresh on path change

### DIFF
--- a/src/shared/components/Projects/ProjectForm.tsx
+++ b/src/shared/components/Projects/ProjectForm.tsx
@@ -96,6 +96,7 @@ export interface ProjectFormProps {
   };
   busy?: boolean;
   onSubmit?(project: ProjectFormProps['project']): any;
+  mode?: 'create' | 'edit';
 }
 
 /**
@@ -107,6 +108,7 @@ const ProjectForm: React.FunctionComponent<ProjectFormProps> = ({
   project,
   busy = false,
   onSubmit = () => {},
+  mode = 'create',
 }) => {
   // logic for generating dynamic prefix mapping fields in form
   const currentId =
@@ -233,7 +235,7 @@ const ProjectForm: React.FunctionComponent<ProjectFormProps> = ({
           {getFieldDecorator('label', {
             initialValue: project ? project.label : '',
             rules: [{ required: true }],
-          })(<Input placeholder="Label" />)}
+          })(<Input placeholder="Label" disabled={mode === 'edit'} />)}
         </Form.Item>
         <Form.Item label="Base" {...formItemLayout}>
           {getFieldDecorator('base', {

--- a/src/shared/views/Home.tsx
+++ b/src/shared/views/Home.tsx
@@ -195,6 +195,7 @@ const Home: React.FunctionComponent<HomeProps> = ({
             }}
             onSubmit={(p: Project) => saveAndModify(selectedProject, p)}
             busy={formBusy}
+            mode="edit"
           />
         )}
       </Drawer>

--- a/src/shared/views/Home.tsx
+++ b/src/shared/views/Home.tsx
@@ -46,14 +46,18 @@ const Home: React.FunctionComponent<HomeProps> = ({
   const [selectedProject, setSelectedProject] = React.useState<
     Project | undefined
   >(undefined);
-
   React.useEffect(
     () => {
-      if (activeOrg.label !== match.params.org) {
+      console.log(match);
+      console.log(activeOrg.label);
+      if (
+        activeOrg.label !== match.params.org ||
+        (projects.length === 0 && !busy)
+      ) {
         fetchProjects(match.params.org);
       }
     },
-    [match.params.org]
+    [match.path]
   );
 
   const saveAndCreate = (newProject: Project) => {


### PR DESCRIPTION
Label input disabled when editing:

![screenshot from 2019-01-18 11-09-57](https://user-images.githubusercontent.com/4364154/51380281-a8173d00-1b11-11e9-9d1e-7cf64a1db414.png)

And fetching list projects bug fix. Currently, landing on https://bbp-nexus.epfl.ch/staging/web/kenny/search/_search and clicking on the `kenny` org link fro the breadcrumb doesn't trigger a `fetchProject` call. This is now fixed.