### PR TITLE
323 hover resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10437,9 +10437,9 @@
       }
     },
     "moment": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
-      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moo": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "identicon.js": "^2.3.3",
     "jwt-decode": "^2.2.0",
     "md5": "^2.2.1",
+    "moment": "^2.24.0",
     "morgan": "^1.9.1",
     "object-hash": "^1.3.1",
     "query-string": "^6.2.0",

--- a/src/shared/App.less
+++ b/src/shared/App.less
@@ -18,3 +18,13 @@
 .ant-upload.ant-upload-drag .ant-upload {
   padding: 1em;
 }
+
+.ant-drawer-header {
+  padding: 19px 24px;
+}
+.ant-drawer-content-wrapper {
+  top: 60px;
+}
+.ant-drawer-right.ant-drawer-open .ant-drawer-content-wrapper {
+  box-shadow: -2px 8px 8px rgba(0, 0, 0, 0.15);
+}

--- a/src/shared/components/Resources/ResourceItem.tsx
+++ b/src/shared/components/Resources/ResourceItem.tsx
@@ -6,6 +6,8 @@ import './Resources.less';
 import { Meta } from 'antd/lib/list/Item';
 import moment = require('moment');
 
+const MOUSE_ENTER_DELAY = 0.5;
+
 export interface ResourceItemProps extends ResourceMetadataCardProps {
   id: string;
   type?: string[];
@@ -52,7 +54,10 @@ const ResourceMetadataCard: React.FunctionComponent<
 const ResourceListItem: React.FunctionComponent<ResourceItemProps> = props => {
   const { type, name, onClick = () => {} } = props;
   return (
-    <Popover content={<ResourceMetadataCard {...props} />}>
+    <Popover
+      content={<ResourceMetadataCard {...props} />}
+      mouseEnterDelay={MOUSE_ENTER_DELAY}
+    >
       <div className="clickable-container resource-item" onClick={onClick}>
         <div className="name">
           <em>{name}</em>

--- a/src/shared/components/Resources/ResourceItem.tsx
+++ b/src/shared/components/Resources/ResourceItem.tsx
@@ -1,34 +1,65 @@
 import * as React from 'react';
-import { List } from 'antd';
+import { Popover, Card } from 'antd';
 import TypesIcon from '../Types/TypesIcon';
 
 import './Resources.less';
+import { Meta } from 'antd/lib/list/Item';
+import moment = require('moment');
 
-const { Item } = List;
-
-export interface ResourceItemProps {
-  name?: string;
+export interface ResourceItemProps extends ResourceMetadataCardProps {
   id: string;
   type?: string[];
-  constrainedBy: string;
   onClick?(): void;
   onEdit?(): void;
 }
 
-const ResourceListItem: React.FunctionComponent<ResourceItemProps> = ({
-  constrainedBy,
-  type,
-  name,
-  onClick = () => {},
-}) => {
+export interface ResourceMetadataCardProps {
+  name?: string;
+  createdAt: string;
+  updatedAt: string;
+  constrainedBy: string;
+}
+
+const ResourceMetadataCard: React.FunctionComponent<
+  ResourceMetadataCardProps
+> = props => {
+  const { constrainedBy, name, createdAt, updatedAt } = props;
   return (
-    <div className="clickable-container resource-item" onClick={onClick}>
-      <div className="name">
-        <em>{name}</em>
+    <Card>
+      <Meta
+        title={
+          <div
+            className="name"
+            style={{ display: 'flex', justifyContent: 'space-between' }}
+          >
+            <em>{name}</em>
+            <span>{moment(createdAt).format('DD/MM/YYYY')}</span>
+          </div>
+        }
+        description={
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div>last updated {moment(updatedAt).fromNow()}</div>
+            <div>
+              constrained by <b>{constrainedBy}</b>
+            </div>
+          </div>
+        }
+      />
+    </Card>
+  );
+};
+
+const ResourceListItem: React.FunctionComponent<ResourceItemProps> = props => {
+  const { type, name, onClick = () => {} } = props;
+  return (
+    <Popover content={<ResourceMetadataCard {...props} />}>
+      <div className="clickable-container resource-item" onClick={onClick}>
+        <div className="name">
+          <em>{name}</em>
+        </div>
+        {type && type.length && <TypesIcon type={type} />}
       </div>
-      {/* <div className="schema">{constrainedBy}</div> */}
-      {type && type.length && <TypesIcon type={type} />}
-    </div>
+    </Popover>
   );
 };
 

--- a/src/shared/components/Resources/ResourceItem.tsx
+++ b/src/shared/components/Resources/ResourceItem.tsx
@@ -40,7 +40,7 @@ const ResourceMetadataCard: React.FunctionComponent<
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <div>last updated {moment(updatedAt).fromNow()}</div>
             <div>
-              constrained by <b>{constrainedBy}</b>
+              schema: <b>{constrainedBy}</b>
             </div>
           </div>
         }


### PR DESCRIPTION
# Resource Preview
![screenshot 2019-01-31 at 11 39 54](https://user-images.githubusercontent.com/5485824/52049062-1ebe2c80-254d-11e9-9184-c0f3f069ccb5.png)

a simple addition to view some useful stats about a resource, such as `createdAt` time. 

https://github.com/BlueBrain/nexus/issues/323