### PR TITLE
Minor resource accessbility updates

### DIFF
--- a/src/shared/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/shared/components/Breadcrumb/Breadcrumb.tsx
@@ -41,7 +41,9 @@ const BreadcrumbsListComponent: React.FunctionComponent<BreadcrumbProps> = ({
               }`}
               key={`${path}-${index}`}
             >
-              <NavLink to={path}>{component}</NavLink>
+              <NavLink tabIndex={-1} to={path}>
+                {component}
+              </NavLink>
             </li>
             {!!(index < breadcrumbs.length - 1) && (
               <li

--- a/src/shared/components/Lists/ListControlPanel.tsx
+++ b/src/shared/components/Lists/ListControlPanel.tsx
@@ -24,27 +24,15 @@ const ListControlPanel: React.FunctionComponent<ListControlPanelProps> = ({
   onClear,
   onCloneList,
 }) => {
-  const inputEl = React.useRef(null);
+  const inputEl = React.createRef<Input>();
   const [value, setTextQueryValue] = React.useState(query.textQuery);
   const handleInputChange = (e: any) => {
     const value = e.target.value;
     setTextQueryValue(value);
-    // if cleared or removed, send changed event
-    if (!value) {
-      onTextQueryChange(value);
-    }
   };
 
   const handleInputEnter = () => {
     onTextQueryChange(value);
-  };
-
-  const handleBlurEvent = (e: any) => {
-    const blurValue = e.target.value;
-    if (blurValue === query.textQuery) {
-      return;
-    }
-    handleInputEnter();
   };
 
   const handleFilterUpdate = (value: any) => {

--- a/src/shared/components/Lists/ListControlPanel.tsx
+++ b/src/shared/components/Lists/ListControlPanel.tsx
@@ -4,6 +4,7 @@ import FilterDropdown from './FilterDropdown';
 import { Link } from 'react-router-dom';
 
 interface ListControlPanelProps {
+  listIndex: number;
   query: { filters: any; textQuery?: string };
   queryPath: string;
   filterValues: { [key: string]: { key: string; count: number }[] } | {};
@@ -14,6 +15,7 @@ interface ListControlPanelProps {
 }
 
 const ListControlPanel: React.FunctionComponent<ListControlPanelProps> = ({
+  listIndex,
   query,
   queryPath,
   filterValues,
@@ -61,9 +63,10 @@ const ListControlPanel: React.FunctionComponent<ListControlPanelProps> = ({
         value={value}
         ref={inputEl}
         onPressEnter={handleInputEnter}
-        onBlur={handleBlurEvent}
+        // onBlur={handleBlurEvent}
         onChange={handleInputChange}
         allowClear={true}
+        tabIndex={listIndex + 1}
         addonAfter={
           !!Object.keys(filterValues).length && (
             <Tooltip title="Filter query">

--- a/src/shared/components/Lists/ListItem.tsx
+++ b/src/shared/components/Lists/ListItem.tsx
@@ -115,6 +115,7 @@ const ListItemContainer: React.FunctionComponent<ListItemContainerProps> = ({
         <Icon type="close" className="close-button" onClick={handleDelete} />
       </h3>
       <ListControlPanel
+        listIndex={listIndex}
         query={query}
         filterValues={filterValues}
         onTextQueryChange={handleTextQueryChange}

--- a/src/shared/components/Resources/ResourceItem.tsx
+++ b/src/shared/components/Resources/ResourceItem.tsx
@@ -11,6 +11,7 @@ const MOUSE_ENTER_DELAY = 0.5;
 export interface ResourceItemProps extends ResourceMetadataCardProps {
   id: string;
   type?: string[];
+  index: number;
   onClick?(): void;
   onEdit?(): void;
 }
@@ -52,13 +53,29 @@ const ResourceMetadataCard: React.FunctionComponent<
 };
 
 const ResourceListItem: React.FunctionComponent<ResourceItemProps> = props => {
-  const { type, name, onClick = () => {} } = props;
+  const { type, name, index, onClick = () => {} } = props;
+  const containerRef = React.createRef<HTMLDivElement>();
+
+  const handleKeyPress = (e: any) => {
+    const code = e.keyCode || e.which;
+    // enter is pressed
+    if (code === 13 && containerRef.current && document) {
+      onClick();
+    }
+  };
+
   return (
     <Popover
       content={<ResourceMetadataCard {...props} />}
       mouseEnterDelay={MOUSE_ENTER_DELAY}
     >
-      <div className="clickable-container resource-item" onClick={onClick}>
+      <div
+        ref={containerRef}
+        className="clickable-container resource-item"
+        onClick={onClick}
+        onKeyPress={handleKeyPress}
+        tabIndex={index + 1}
+      >
         <div className="name">
           <em>{name}</em>
         </div>

--- a/src/shared/components/Resources/ResourceList.tsx
+++ b/src/shared/components/Resources/ResourceList.tsx
@@ -31,6 +31,21 @@ const ResourceList: React.FunctionComponent<ResourceListProps> = ({
   const [selectedResource, setSelectedResource] = React.useState(
     null as Resource | null
   );
+  const handleKeyPress = (e: KeyboardEvent) => {
+    const code = e.keyCode || e.which;
+    // enter is pressed
+    if (code === 27 && selectedResource) {
+      setSelectedResource(null);
+    }
+  };
+
+  React.useEffect(() => {
+    document.addEventListener('keydown', handleKeyPress, false);
+    return () => {
+      document.removeEventListener('keydown', handleKeyPress, false);
+    };
+  });
+
   return (
     <React.Fragment>
       <List
@@ -55,9 +70,10 @@ const ResourceList: React.FunctionComponent<ResourceListProps> = ({
               }
             : undefined
         }
-        renderItem={(resource: Resource) => {
+        renderItem={(resource: Resource, index: number) => {
           return (
             <ResourceItem
+              index={index}
               key={resource.id}
               name={resource.name}
               {...resource}

--- a/src/shared/components/Resources/Resources.less
+++ b/src/shared/components/Resources/Resources.less
@@ -34,7 +34,9 @@
   display: flex;
   justify-content: space-between;
   padding: 1em;
-  &:hover {
+  &:hover,
+  &:active,
+  &:focus {
     background-color: @primary-background-subtle;
     .ant-list-item-meta-title {
       margin-left: 0.25em;
@@ -42,7 +44,6 @@
     }
   }
   & > .name {
-    font-weight: bold;
     font-size: 14px;
     width: 70%;
     text-overflow: ellipsis;

--- a/src/shared/store/actions/queryResource.ts
+++ b/src/shared/store/actions/queryResource.ts
@@ -127,6 +127,9 @@ export const makeESQuery = (query?: { filters: any; textQuery?: string }) => {
         },
       };
     }
+    if (must.length === 0) {
+      return {};
+    }
     return {
       query: {
         ...must[0],


### PR DESCRIPTION
# Minor Resource List Accessibility Changes
![kapture 2019-01-31 at 15 47 40](https://user-images.githubusercontent.com/5485824/52061854-9b620280-256f-11e9-99b0-1a257d1ced70.gif)

You can now tab down to the text query interface directly from the Browser URL bar,
tab between items in the resource lists, 
press enter while resource items are in focus to bring up their details view, 
press escape to go back to the list page. 